### PR TITLE
Selections API not showing swagger definition

### DIFF
--- a/src/api/EmployerFavouritesApi/Startup.cs
+++ b/src/api/EmployerFavouritesApi/Startup.cs
@@ -81,6 +81,7 @@ namespace DfE.EmployerFavourites.Api
                 var xmlFile = $"{Assembly.GetExecutingAssembly().GetName().Name}.xml";
                 var xmlPath = Path.Combine(AppContext.BaseDirectory, xmlFile);
                 c.IncludeXmlComments(xmlPath);
+                c.CustomSchemaIds(i => i.FullName);
             });
         }
 


### PR DESCRIPTION
Looks like swagger couldn't deal with classes of the same name.  Changed setting to make it use the full name for Id'ing classes.